### PR TITLE
docs(coding-guidelines): add Mark Hermeling

### DIFF
--- a/arewesafetycriticalyet.org/docs/coding_guidelines/2_members.md
+++ b/arewesafetycriticalyet.org/docs/coding_guidelines/2_members.md
@@ -75,4 +75,5 @@
 | Marcos Borges, PhD         | Individual                             | Producer                    | @MarcosBorgesPhD   |
 | Stefan Akatyschew          | Individual                             | Producer                    | @fried-gluttony    |
 | Jeongsoo Lee               | GitHub                                 | Observer                    | @jeongsoolee09     |
+| Mark Hermeling             | AdaCore                                | Observer                    | @markhermeling     |
 


### PR DESCRIPTION
Adds Mark Hermeling to the Coding Guidelines subcommittee as an AdaCore observer.

Closes #711.