### PR TITLE
fix: route membership issues to consortium project

### DIFF
--- a/.github/workflows/add-membership-application-to-project.yml
+++ b/.github/workflows/add-membership-application-to-project.yml
@@ -10,8 +10,8 @@ jobs:
     name: Add membership issue to project
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/add-to-project@v1.0.2
+      - uses: actions/add-to-project@v2.0.0
         with:
-          project-url: https://github.com/orgs/rustfoundation/projects/2
+          project-url: https://github.com/orgs/Safety-Critical-Rust-Consortium/projects/5
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
           labeled: "membership application"


### PR DESCRIPTION
## Summary

- Route membership applications to the Safety Critical Rust Consortium's membership project.
- Upgrade `actions/add-to-project` from `v1.0.2` to `v2.0.0`.

## Context

The repository moved from `rustfoundation` to
`Safety-Critical-Rust-Consortium`, but the membership automation continued
targeting `rustfoundation/projects/2`.

Because the repository and configured project had different owners,
`actions/add-to-project` treated them as cross-organization resources and
created URL-only draft cards in the old project. The workflow runs still
reported success.

This changes the destination to:

https://github.com/orgs/Safety-Critical-Rust-Consortium/projects/5

With matching repository and project owners, the action will add the actual
issue as a project item.

## Validation

- Parsed the workflow successfully as YAML.
- Ran `git diff --check`.
- Confirmed the branch contains only the intended two-line workflow change.

## Post-Merge Verification

Confirm the next issue carrying the `membership application` label:

- Appears in project 5 as an Issue rather than a Draft.
- Produces an Actions log containing `Creating project item`.
- Does not produce `Creating draft issue in project`.

The existing `ADD_TO_PROJECT_PAT` may need replacement if it cannot write to
the new organization project. Historical applications require a separate
backfill.
